### PR TITLE
[ENHANCEMENT] Convertir le deletGame en clean architecture

### DIFF
--- a/lib/application/controllers/game/game-controller.js
+++ b/lib/application/controllers/game/game-controller.js
@@ -29,8 +29,11 @@ module.exports = {
         .json(results)
         .end()
     } catch (error) {
+      if (error instanceof NotFound) {
+        return res.status(404).send(error.message)
+      }
       return res
-        .status(400)
+        .status(500)
         .end()
     }
   },

--- a/lib/application/controllers/game/game-controller.js
+++ b/lib/application/controllers/game/game-controller.js
@@ -131,8 +131,24 @@ module.exports = {
     }
   },
 
-  delete (req, res) {
+  async delete (req, res) {
     const { id } = req.params
-    Game.deleteOne({ _id: id }).then(() => res.status(200).end()).catch(() => res.status(403).end())
+    const { userId } = req.body
+
+    try {
+      const result = await useCases.deleteOneGame({ gameId: id, userId })
+      return res
+        .status(200)
+        .send(result)
+        .end()
+    } catch (error) {
+      if (error instanceof NotFound) {
+        return res.status(404).send(error.message)
+      }
+      return res
+        .status(500)
+        .json(error)
+        .end()
+    }
   }
 }

--- a/lib/application/controllers/game/index.js
+++ b/lib/application/controllers/game/index.js
@@ -14,6 +14,6 @@ router.put('/update/pass/:id', GameController.updateGameOnPass)
 
 router.put('/update/move/:id', GameController.updateGameOnMove)
 
-router.delete('/delete/:id', GameController.delete)
+router.put('/delete/:id', GameController.delete)
 
 module.exports = router

--- a/lib/domain/useCases/delete-one-game.js
+++ b/lib/domain/useCases/delete-one-game.js
@@ -1,0 +1,17 @@
+const { NotFound } = require('../models/errors')
+
+module.exports = async function deleteOneGame ({
+  gameId,
+  userId,
+  gameRepository
+}) {
+  const userGames = await gameRepository.getUserGames(userId)
+
+  const gameToDelete = userGames.find(game => String(game._id) === String(gameId))
+
+  if (!gameToDelete) {
+    throw new NotFound()
+  }
+
+  return gameRepository.deleteGame(gameToDelete._id)
+}

--- a/lib/domain/useCases/delete-one-game.js
+++ b/lib/domain/useCases/delete-one-game.js
@@ -13,5 +13,5 @@ module.exports = async function deleteOneGame ({
     throw new NotFound()
   }
 
-  return gameRepository.deleteGame(gameToDelete._id)
+  return gameRepository.deleteGame({ gameId: gameToDelete._id })
 }

--- a/lib/domain/useCases/index.js
+++ b/lib/domain/useCases/index.js
@@ -7,6 +7,7 @@ const dependencies = {
 const { injectDependencies } = require('../../infrasctucture/utils/dependency-injection')
 
 module.exports = injectDependencies({
+  deleteOneGame: require('./delete-one-game'),
   getAllGames: require('./get-all-games'),
   getOneGame: require('./get-one-game'),
   getUserGames: require('./get-user-games'),

--- a/lib/infrasctucture/repositories/game-repository.js
+++ b/lib/infrasctucture/repositories/game-repository.js
@@ -53,5 +53,17 @@ module.exports = {
       throw new NotFound()
     }
     return gameData
+  },
+
+  async deleteGame ({ gameId }) {
+    const result = await Game.deleteOne({ _id: gameId })
+    if (_isNoGameFound(result)) {
+      throw new NotFound()
+    }
+    return result
   }
+}
+
+function _isNoGameFound (result) {
+  return result.n === 0 && result.deletedCount === 0
 }

--- a/lib/test/api/acceptance/game-router.test.js
+++ b/lib/test/api/acceptance/game-router.test.js
@@ -173,7 +173,7 @@ describe('Acceptance | Api | gameRouter', () => {
 
       // when
       chai.request(app)
-        .delete(`/api/game/delete/${id}`)
+        .put(`/api/game/delete/${id}`)
         .send(data)
         .end((_err, res) => {
           // then

--- a/lib/test/api/acceptance/game-router.test.js
+++ b/lib/test/api/acceptance/game-router.test.js
@@ -167,13 +167,18 @@ describe('Acceptance | Api | gameRouter', () => {
     it('should delete one game', (done) => {
       // given
       const id = gameId
+      const data = {
+        userId: playerTwoDatas._id
+      }
 
       // when
       chai.request(app)
         .delete(`/api/game/delete/${id}`)
+        .send(data)
         .end((_err, res) => {
           // then
           expect(res).to.have.status(200)
+          expect(res.body.deletedCount).to.equal(1)
           done()
         })
     })

--- a/lib/test/api/integration/infrasctructure/repositories/game-repository.test.js
+++ b/lib/test/api/integration/infrasctructure/repositories/game-repository.test.js
@@ -5,11 +5,16 @@ const mongoose = require('mongoose')
 const catchErr = require('../../../../test-helper')
 const { NotFound } = require('../../../../../domain/models/errors')
 
-after(async () => {
-  await mongoose.connection.db.dropDatabase()
-})
-
 describe('Integration | Infrastructure | Repository | GameRepository', async () => {
+  before(async () => {
+    const collections = await mongoose.connection.db.collections()
+
+    for (const collection of collections) {
+      if (collection.namespace === 'test.games') {
+        await collection.drop()
+      }
+    }
+  })
   describe('#getAllGames', () => {
     it('Should throw a not found error if no games are stored in DB', async () => {
       // when

--- a/lib/test/api/integration/infrasctructure/repositories/game-repository.test.js
+++ b/lib/test/api/integration/infrasctructure/repositories/game-repository.test.js
@@ -258,4 +258,40 @@ describe('Integration | Infrastructure | Repository | GameRepository', async () 
       expect(result).to.be.instanceOf(NotFound)
     })
   })
+
+  describe('#deleteGame', () => {
+    it('Should delete a game', async () => {
+      // given
+      const blackPlayer = require('mongoose').Types.ObjectId()
+      const whitePlayer = require('mongoose').Types.ObjectId()
+      const game = new Game({
+        blackPassCount: 1,
+        whitePassCount: 1,
+        game: Symbol('game'),
+        blackPlayer,
+        whitePlayer,
+        currentPlayer: require('mongoose').Types.ObjectId()
+      })
+
+      const savedGame = await game.save()
+
+      // when
+      const result = await gameRepository.deleteGame({
+        gameId: savedGame._id
+      })
+
+      // then
+      expect(result.deletedCount).to.equal(1)
+    })
+
+    it('Should throw an error if no game found', async () => {
+      // when
+      const result = await catchErr(gameRepository.deleteGame)({
+        gameId: require('mongoose').Types.ObjectId()
+      })
+
+      // then
+      expect(result).to.be.instanceOf(NotFound)
+    })
+  })
 })

--- a/lib/test/api/unit/domain/useCases/delete-one-game.test.js
+++ b/lib/test/api/unit/domain/useCases/delete-one-game.test.js
@@ -1,0 +1,147 @@
+// Chai
+const chai = require('chai')
+const expect = chai.expect
+chai.use(require('chai-as-promised'))
+chai.use(require('chai-sorted'))
+// Sinon
+const sinon = require('sinon')
+chai.use(require('sinon-chai'))
+// Other
+const deleteOneGame = require('../../../../../domain/useCases/delete-one-game')
+const gameRepository = require('../../../../../infrasctucture/repositories/game-repository')
+const catchErr = require('../../../../test-helper')
+const { NotFound } = require('../../../../../domain/models/errors')
+
+describe('Unit | Api | UseCase | delete-one-game', () => {
+  describe('#deleteOneGame', () => {
+    beforeEach(() => {
+      sinon.stub(gameRepository, 'getUserGames')
+      sinon.stub(gameRepository, 'deleteGame')
+    })
+
+    afterEach(() => {
+      sinon.restore()
+    })
+
+    it('should return delete game confirmation', async () => {
+      // given
+      const gameId = require('mongoose').Types.ObjectId()
+      const whitePlayerData = {
+        pseudo: 'whitePlayer',
+        _id: require('mongoose').Types.ObjectId()
+      }
+
+      const blackPlayerData = {
+        pseudo: 'blackPlayer',
+        _id: require('mongoose').Types.ObjectId()
+      }
+
+      const gamesData = [
+        {
+          blackPassCount: 0,
+          whitePassCount: 0,
+          _id: require('mongoose').Types.ObjectId(),
+          blackPlayer: blackPlayerData._id,
+          whitePlayer: whitePlayerData._id,
+          currentPlayer: blackPlayerData._id,
+          __v: 0
+        },
+        {
+          blackPassCount: 0,
+          whitePassCount: 0,
+          _id: gameId,
+          blackPlayer: blackPlayerData._id,
+          whitePlayer: whitePlayerData._id,
+          currentPlayer: blackPlayerData._id,
+          __v: 0
+        }
+      ]
+
+      gameRepository.getUserGames.resolves(gamesData)
+
+      const expectedResult = {
+        n: 1,
+        ok: 1,
+        deletedCount: 1
+      }
+
+      gameRepository.deleteGame.resolves(expectedResult)
+
+      // when
+      const promise = await deleteOneGame({
+        gameId,
+        userId: blackPlayerData._id,
+        gameRepository
+      })
+
+      // then
+      expect(promise).to.deep.equal(expectedResult)
+    })
+
+    it('should throw an error if user has no game', async () => {
+      // given
+      const unKnownUserId = 'unKnownUserId'
+      const gameId = require('mongoose').Types.ObjectId()
+
+      gameRepository.getUserGames.rejects(new NotFound())
+
+      // when
+      const promise = await catchErr(deleteOneGame)({
+        gameId,
+        userId: unKnownUserId,
+        gameRepository
+      })
+
+      // then
+      expect(promise).to.be.instanceOf(NotFound)
+    })
+
+    it('should throw an error if user has games but none matches gameId', async () => {
+      // given
+      // given
+      const gameId = require('mongoose').Types.ObjectId()
+      const whitePlayerData = {
+        pseudo: 'whitePlayer',
+        _id: require('mongoose').Types.ObjectId()
+      }
+
+      const blackPlayerData = {
+        pseudo: 'blackPlayer',
+        _id: require('mongoose').Types.ObjectId()
+      }
+
+      const gamesData = [
+        {
+          blackPassCount: 0,
+          whitePassCount: 0,
+          _id: require('mongoose').Types.ObjectId(),
+          blackPlayer: blackPlayerData._id,
+          whitePlayer: whitePlayerData._id,
+          currentPlayer: blackPlayerData._id,
+          __v: 0
+        },
+        {
+          blackPassCount: 0,
+          whitePassCount: 0,
+          _id: require('mongoose').Types.ObjectId(),
+          blackPlayer: blackPlayerData._id,
+          whitePlayer: whitePlayerData._id,
+          currentPlayer: blackPlayerData._id,
+          __v: 0
+        }
+      ]
+
+      gameRepository.getUserGames.resolves(gamesData)
+
+      // when
+      const promise = await catchErr(deleteOneGame)({
+        gameId,
+        userId: blackPlayerData._id,
+        gameRepository
+      })
+
+      // then
+      expect(promise).to.be.instanceOf(NotFound)
+    })
+  })
+})

--- a/react/src/components/GamesList/GamesList.js
+++ b/react/src/components/GamesList/GamesList.js
@@ -35,10 +35,11 @@ class GamesList extends Component {
     await this.setState({ opponent: result })
   }
 
-  deleteGame () {
+  async deleteGame () {
     const gameId = this.props.gameData._id
-    axios.delete(`${uri}/game/delete/${gameId}`)
-      .then(() => this.props.updateVue())
+    const { userId } = this.state
+    await axios.put(`${uri}/game/delete/${gameId}`, { userId })
+    return this.props.updateVue()
   }
 
   render () {

--- a/react/src/components/HomeIn/HomeIn.js
+++ b/react/src/components/HomeIn/HomeIn.js
@@ -39,7 +39,7 @@ export default class HomeIn extends Component {
   getUsersGame (id) {
     return axios.get(`${uri}/game/user/${id}`)
       .then(res => this.setState({ games: res.data }))
-      .catch(err => console.error(err))
+      .catch(() => this.setState({ games: [] }))
   }
 
   /**


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, il reste des morceaux de l'application qui ne sont pas encore convertis en clean architecture, dont la suppression d'une partie.

## :robot: Solution
Convertir la méthode deleteGame du game controller en clean architecture (controller => useCase => repository) et ajouter des tests

## :100: Pour tester
- Créer deux utilisateurs
- Se connecter
- Créer une partie
- Supprimer la partie
- Constater que la page se recharge et que la partie en question a disparu